### PR TITLE
Querzüge basieren nicht mehr auf Längszügen sondern auf Elementarzügen

### DIFF
--- a/Position.java
+++ b/Position.java
@@ -44,6 +44,14 @@ public class Position
         return y;
     }
     
+    public Position gibZiel(Vektor v) {
+        return new Position(x+v.gibX(), y+v.gibY());
+    }
+    
+    public Position gibMitte(Position p) {
+        return new Position( (x+p.gibX())/2, (y+p.gibY())/2 );
+    }
+    
     /**
      * zulaessig prüft ob die Position im Feld liegt
      * 


### PR DESCRIPTION
Es gab ein Problem damit, dass Querzüge auf Längszügen basierten. Der Zug A1 A3 B2 schiebt dann 9 Kugeln! Stattdessen wurden Elementarzüge eingeführt, die nur eine Kugel verschieben.

Außerdem wird vor der Durchführung zweier bzw. dreier Elementarzüge im Rahmen eines Querzuges jetzt vorher geprüft, ob alle Elementarzüge durchführbar sind, erst dann wird der Querzug als atomar vorgenommen.
